### PR TITLE
get the correct increment backup(revert #125.)

### DIFF
--- a/backup.c
+++ b/backup.c
@@ -103,7 +103,7 @@ do_backup_database(parray *backup_list, pgBackupOption bkupopt)
 			pgBackup   *prev_backup;
 
 			/* find last completed database backup */
-			prev_backup = catalog_get_last_full_backup(backup_list);
+			prev_backup = catalog_get_last_data_backup(backup_list);
 			if (prev_backup == NULL)
 			{
 				if (current.full_backup_on_error)
@@ -192,7 +192,7 @@ do_backup_database(parray *backup_list, pgBackupOption bkupopt)
 		uint32		xlogid, xrecoff;
 
 		/* find last completed database backup */
-		prev_backup = catalog_get_last_full_backup(backup_list);
+		prev_backup = catalog_get_last_data_backup(backup_list);
 		if (prev_backup == NULL || prev_backup->tli != current.tli)
 		{
 			if (current.full_backup_on_error)


### PR DESCRIPTION
Before, we actually got the  difference backup, not the incremental backup.
TO solve this probem ,revert #125.

However, if a physical backup file is deleted(rm command, etc.) other than the pg_rman delete command of pg_rman,
It cannot find the correct status of a full backup and incremental backup.(please refer to #154 to details)
WE will solve this problem, at the next major upgarde.