### PR TITLE
get the correct increment backup

### DIFF
--- a/backup.c
+++ b/backup.c
@@ -103,7 +103,7 @@ do_backup_database(parray *backup_list, pgBackupOption bkupopt)
 			pgBackup   *prev_backup;
 
 			/* find last completed database backup */
-			prev_backup = catalog_get_last_full_backup(backup_list);
+			prev_backup = catalog_get_last_data_backup(backup_list);
 			if (prev_backup == NULL)
 			{
 				if (current.full_backup_on_error)
@@ -192,7 +192,7 @@ do_backup_database(parray *backup_list, pgBackupOption bkupopt)
 		uint32		xlogid, xrecoff;
 
 		/* find last completed database backup */
-		prev_backup = catalog_get_last_full_backup(backup_list);
+		prev_backup = catalog_get_last_data_backup(backup_list);
 		if (prev_backup == NULL || prev_backup->tli != current.tli)
 		{
 			if (current.full_backup_on_error)

--- a/catalog.c
+++ b/catalog.c
@@ -266,7 +266,7 @@ err_proc:
  * Find the last completed database full valid backup from the backup list.
  */
 pgBackup *
-catalog_get_last_full_backup(parray *backup_list)
+catalog_get_last_data_backup(parray *backup_list)
 {
 	int			i;
 	pgBackup   *backup = NULL;
@@ -276,9 +276,8 @@ catalog_get_last_full_backup(parray *backup_list)
 	{
 		backup = (pgBackup *) parray_get(backup_list, i);
 
-		/* Return the first full valid backup. */
-		if (backup->backup_mode == BACKUP_MODE_FULL &&
-			backup->status == BACKUP_STATUS_OK)
+		/* we need completed database backup */
+		if (backup -> status == BACKUP_STATUS_OK && HAVE_DATABASE(backup))
 			return backup;
 	}
 

--- a/pg_rman.h
+++ b/pg_rman.h
@@ -285,7 +285,7 @@ extern void pgBackupValidate(pgBackup *backup, bool size_only, bool for_get_time
 /* in catalog.c */
 extern pgBackup *catalog_get_backup(time_t timestamp);
 extern parray *catalog_get_backup_list(const pgBackupRange *range);
-extern pgBackup *catalog_get_last_full_backup(parray *backup_list);
+extern pgBackup *catalog_get_last_data_backup(parray *backup_list);
 extern pgBackup *catalog_get_last_arclog_backup(parray *backup_list);
 extern pgBackup *catalog_get_last_srvlog_backup(parray *backup_list);
 


### PR DESCRIPTION
Before, we actually got the  difference backup, not the incremental backup.
TO solve this probem ,revert #125.

However, if a physical backup file is deleted(rm command, etc.) other than the pg_rman delete command of pg_rman,
It cannot find the correct status of a full backup and incremental backup.(please refer to #154 to details)
WE will solve this problem, at the next major upgarde.